### PR TITLE
adjust authorship policy header level

### DIFF
--- a/content/02.authorship_policy.md
+++ b/content/02.authorship_policy.md
@@ -1,4 +1,4 @@
-# Authorship Policy
+## Authorship Policy
 
 We note that the author list for this paper is, by design, extensive.
 We have separated the authors into those that contributed to the text (whose names are ordered **somehow TBD**) and those that are members of the `yt` community.
@@ -6,7 +6,7 @@ The authors from each group have been indicated in the respective author affilia
 
 This paper was developed collaboratively, using the Manubot [@url:https://github.com/greenelab/manubot] system for collaborating on and reviewing contributed text.
 
-> 
+>
 > To add yourself to the author list, please follow the instructions in our
 > [README](https://github.com/yt-project/yt-4.0-paper/blob/master/README.md#authorship-policy).
-> 
+>


### PR DESCRIPTION
The "Authorship Policy" section in the TOC is showing up as a top-level section: 

<img width="1085" height="551" alt="Screenshot 2025-08-18 at 10 42 04 AM" src="https://github.com/user-attachments/assets/f7343a3b-c3ad-49e1-8b14-730d8ecbfb9d" />

This PR updates it to match the section level of the other pages. 

If you want to keep it top level for visibility, I think it'd be nice to add another top level section ("Paper"? "Content"?) under which the rest of the paper would nest so that it doesn't look like the rest of the paper is a subsection of the "Authorship Policy". 
